### PR TITLE
[Chore]exclude .node-version from Renovate management(#55)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,12 @@
         "typescript"
       ],
       "groupName": "minor and patch dependencies"
+    },
+    {
+      "matchFiles": [
+        ".node-version"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Add package rule to disable Renovate updates for .node-version file to allow manual control of Node.js version.