### PR TITLE
[Fix]fix .node-version paths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
     },
     {
       "matchFiles": [
-        ".node-version"
+        "**/.node-version"
       ],
       "enabled": false
     }


### PR DESCRIPTION
.node-versionがrenovateの管理下から除外されていなかったのでパスを修正